### PR TITLE
Removed ioctl loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/src/lib

--- a/src/controlblock/SNESGamepad.cpp
+++ b/src/controlblock/SNESGamepad.cpp
@@ -37,9 +37,6 @@ void SNESGamepad::initialize(InputDevice::Channel_e channel)
     // Setup the uinput device
     ioctl(uinp_fd, UI_SET_EVBIT, EV_KEY);
     ioctl(uinp_fd, UI_SET_EVBIT, EV_REL);
-	for (int i = 0; i < 256; i++) {
-		ioctl(uinp_fd, UI_SET_KEYBIT, i);
-	}
 
     // gamepad, buttons
     ioctl(uinp_fd, UI_SET_KEYBIT, BTN_A);


### PR DESCRIPTION
Removed ioctl loop that was causing issues with SNES controllers working in emulators. 

Before: D-Pad worked, A/B was mismapped to Select/Start

Also added .gitignore to prevent built files from make showing up in the repository. 