### PR TITLE
Momentary powerswitch support - DO NOT MERGE YET

### DIFF
--- a/src/controlblock/app/ControlBlock.cpp
+++ b/src/controlblock/app/ControlBlock.cpp
@@ -67,7 +67,12 @@ ControlBlock::ControlBlock(IUInputFactory& uiFactoryRef, IControlBlockConfigurat
 
     // initialize the power switch
     if (configRef.getConfiguration(0).isEnabled() && configRef.getConfiguration(0).isPowerSwitchEnabled()) {
-        powerSwitch = new PowerSwitch(*digitalIO[0], PowerSwitch::POWERSWITCH_ENABLED);
+        if (configRef.getConfiguration(0).isPowerSwitchMomentary()) {
+            powerSwitch = new PowerSwitch(*digitalIO[0], PowerSwitch::POWERSWITCH_ENABLED, PowerSwitch::SWITCHTYPE_MOMENTARY);
+        }
+        else {
+            powerSwitch = new PowerSwitch(*digitalIO[0], PowerSwitch::POWERSWITCH_ENABLED, PowerSwitch::SWITCHTYPE_LATCHING);
+        }
     }
 }
 

--- a/src/controlblock/app/ControlBlock.cpp
+++ b/src/controlblock/app/ControlBlock.cpp
@@ -67,7 +67,7 @@ ControlBlock::ControlBlock(IUInputFactory& uiFactoryRef, IControlBlockConfigurat
 
     // initialize the power switch
     if (configRef.getConfiguration(0).isEnabled() && configRef.getConfiguration(0).isPowerSwitchEnabled()) {
-        powerSwitch = new PowerSwitch(*digitalIO[0], PowerSwitch::SHUTDOWN_ACTIVATED);
+        powerSwitch = new PowerSwitch(*digitalIO[0], PowerSwitch::POWERSWITCH_ENABLED);
     }
 }
 

--- a/src/controlblock/app/PowerSwitch.cpp
+++ b/src/controlblock/app/PowerSwitch.cpp
@@ -40,10 +40,12 @@ PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e po
 
 void PowerSwitch::update()
 {
-    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (getPowerSwitchStatus() == POWERSWITCH_UNPRESSED)
-            && (!isShutdownInitiatedValue)) {
-        system("/etc/controlblockswitchoff.sh");
-        isShutdownInitiatedValue = true;
+    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (!isShutdownInitiatedValue)) {
+        if (((powerSwitchType == SWITCHTYPE_LATCHING) && (getPowerSwitchStatus() == POWERSWITCH_UNPRESSED)) ||
+            ((powerSwitchType == SWITCHTYPE_MOMENTARY) && (getPowerSwitchStatus() == POWERSWITCH_PRESSED))) {
+            system("/etc/controlblockswitchoff.sh");
+            isShutdownInitiatedValue = true;
+        }
     }
 }
 

--- a/src/controlblock/app/PowerSwitch.cpp
+++ b/src/controlblock/app/PowerSwitch.cpp
@@ -24,8 +24,8 @@
 #include <iostream>
 #include "PowerSwitch.h"
 
-PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, ShutdownActivated_e doShutdownValue) :
-        doShutdown(doShutdownValue),
+PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e powerSwitchEnabledValue) :
+        powerSwitchEnabled(powerSwitchEnabledValue),
         isShutdownInitiatedValue(false),
         digitalIO(digitalIOReference)
 {
@@ -33,13 +33,13 @@ PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, ShutdownActivated_e doS
     setPowerSignal(PowerSwitch::STATE_ON);
 
 #ifndef NDEBUG
-    std::cout << "Created PowerSwitch. doShutdown: " << doShutdownValue << std::endl;
+    std::cout << "Created PowerSwitch. powerSwitchEnabled: " << powerSwitchEnabledValue << std::endl;
 #endif
 }
 
 void PowerSwitch::update()
 {
-    if ((doShutdown == SHUTDOWN_ACTIVATED) && (getShutdownSignal() == SHUTDOWN_TRUE)
+    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (getShutdownSignal() == SHUTDOWN_TRUE)
             && (!isShutdownInitiatedValue)) {
         system("/etc/controlblockswitchoff.sh");
         isShutdownInitiatedValue = true;

--- a/src/controlblock/app/PowerSwitch.cpp
+++ b/src/controlblock/app/PowerSwitch.cpp
@@ -24,8 +24,9 @@
 #include <iostream>
 #include "PowerSwitch.h"
 
-PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e powerSwitchEnabledValue) :
+PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e powerSwitchEnabledValue, PowerSwitchType_e powerSwitchTypeValue) :
         powerSwitchEnabled(powerSwitchEnabledValue),
+        powerSwitchType(powerSwitchTypeValue),
         isShutdownInitiatedValue(false),
         digitalIO(digitalIOReference)
 {
@@ -33,7 +34,7 @@ PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e po
     setPowerSignal(PowerSwitch::STATE_ON);
 
 #ifndef NDEBUG
-    std::cout << "Created PowerSwitch. powerSwitchEnabled: " << powerSwitchEnabledValue << std::endl;
+    std::cout << "Created PowerSwitch. powerSwitchEnabled: " << powerSwitchEnabledValue << ", powerSwitchType: " << powerSwitchTypeValue << std::endl;
 #endif
 }
 

--- a/src/controlblock/app/PowerSwitch.cpp
+++ b/src/controlblock/app/PowerSwitch.cpp
@@ -40,7 +40,7 @@ PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e po
 
 void PowerSwitch::update()
 {
-    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (getShutdownSignal() == POWERSWITCH_UNPRESSED)
+    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (getPowerSwitchStatus() == POWERSWITCH_UNPRESSED)
             && (!isShutdownInitiatedValue)) {
         system("/etc/controlblockswitchoff.sh");
         isShutdownInitiatedValue = true;
@@ -62,7 +62,7 @@ void PowerSwitch::setPowerSignal(PowerState_e state)
     }
 }
 
-PowerSwitch::PowerSwitchStatus_e PowerSwitch::getShutdownSignal()
+PowerSwitch::PowerSwitchStatus_e PowerSwitch::getPowerSwitchStatus()
 {
     PowerSwitchStatus_e signal;
     if (digitalIO.getLevel(IDigitalIO::DIO_CHANNEL_FROMPOWERSWITCH) == IDigitalIO::DIO_LEVEL_LOW) {

--- a/src/controlblock/app/PowerSwitch.cpp
+++ b/src/controlblock/app/PowerSwitch.cpp
@@ -31,7 +31,7 @@ PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e po
         digitalIO(digitalIOReference)
 {
     digitalIO.configureDevice(IDigitalIO::DIO_DEVICE_POWERSWITCH);
-    setPowerSignal(PowerSwitch::STATE_ON);
+    setPowerState(PowerSwitch::STATE_ON);
 
 #ifndef NDEBUG
     std::cout << "Created PowerSwitch. powerSwitchEnabled: " << powerSwitchEnabledValue << ", powerSwitchType: " << powerSwitchTypeValue << std::endl;
@@ -52,7 +52,7 @@ bool PowerSwitch::isShutdownInitiated() const
     return isShutdownInitiatedValue;
 }
 
-void PowerSwitch::setPowerSignal(PowerState_e state)
+void PowerSwitch::setPowerState(PowerState_e state)
 {
     if (state == STATE_OFF) {
         digitalIO.setLevel(IDigitalIO::DIO_CHANNEL_TOPOWERSWITCH, IDigitalIO::DIO_LEVEL_LOW);

--- a/src/controlblock/app/PowerSwitch.cpp
+++ b/src/controlblock/app/PowerSwitch.cpp
@@ -40,7 +40,7 @@ PowerSwitch::PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e po
 
 void PowerSwitch::update()
 {
-    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (getShutdownSignal() == SHUTDOWN_TRUE)
+    if ((powerSwitchEnabled == POWERSWITCH_ENABLED) && (getShutdownSignal() == POWERSWITCH_UNPRESSED)
             && (!isShutdownInitiatedValue)) {
         system("/etc/controlblockswitchoff.sh");
         isShutdownInitiatedValue = true;
@@ -62,14 +62,14 @@ void PowerSwitch::setPowerSignal(PowerState_e state)
     }
 }
 
-PowerSwitch::ShutdownSignal_e PowerSwitch::getShutdownSignal()
+PowerSwitch::PowerSwitchStatus_e PowerSwitch::getShutdownSignal()
 {
-    ShutdownSignal_e signal;
+    PowerSwitchStatus_e signal;
     if (digitalIO.getLevel(IDigitalIO::DIO_CHANNEL_FROMPOWERSWITCH) == IDigitalIO::DIO_LEVEL_LOW) {
-        signal = SHUTDOWN_FALSE;
+        signal = POWERSWITCH_PRESSED;
     }
     else {
-        signal = SHUTDOWN_TRUE;
+        signal = POWERSWITCH_UNPRESSED;
     }
     return signal;
 }

--- a/src/controlblock/app/PowerSwitch.h
+++ b/src/controlblock/app/PowerSwitch.h
@@ -101,7 +101,7 @@ private:
     bool isShutdownInitiatedValue;
     IDigitalIO& digitalIO;
 
-    void setPowerSignal(PowerState_e state);
+    void setPowerState(PowerState_e state);
     PowerSwitchStatus_e getPowerSwitchStatus();
 
 };

--- a/src/controlblock/app/PowerSwitch.h
+++ b/src/controlblock/app/PowerSwitch.h
@@ -52,19 +52,19 @@ public:
     /**
      * Indicates whether the power switch functionality is enabled or not
      */
-    enum ShutdownActivated_e
+    enum PowerSwitchEnabled_e
     {
-        SHUTDOWN_DEACTIVATED = 0, //!< Power switch is disabled
-        SHUTDOWN_ACTIVATED        //!< Power switch is enabled
+        POWERSWITCH_DISABLED = 0, //!< Power switch is disabled
+        POWERSWITCH_ENABLED       //!< Power switch is enabled
     };
 
     /**
      * Constructor
      * @param digitalInReference - Reference with IDigitalIn interface
      * @param digitalOutReference - Reference with IDigitalOut interface
-     * @param doShutdownValue - Power switch function is enabled or not
+     * @param powerSwitchEnabledValue - Power switch function is enabled or not
      */
-    explicit PowerSwitch(IDigitalIO& digitalIOReference, ShutdownActivated_e doShutdownValue);
+    explicit PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e powerSwitchEnabledValue);
 
     /**
      * Destructor
@@ -86,7 +86,7 @@ public:
     bool isShutdownInitiated() const;
 
 private:
-    ShutdownActivated_e doShutdown;
+    PowerSwitchEnabled_e powerSwitchEnabled;
     bool isShutdownInitiatedValue;
     IDigitalIO& digitalIO;
 

--- a/src/controlblock/app/PowerSwitch.h
+++ b/src/controlblock/app/PowerSwitch.h
@@ -102,7 +102,7 @@ private:
     IDigitalIO& digitalIO;
 
     void setPowerSignal(PowerState_e state);
-    PowerSwitchStatus_e getShutdownSignal();
+    PowerSwitchStatus_e getPowerSwitchStatus();
 
 };
 

--- a/src/controlblock/app/PowerSwitch.h
+++ b/src/controlblock/app/PowerSwitch.h
@@ -41,12 +41,12 @@ public:
     };
 
     /**
-     * Shutdown signal identifiers
+     * Power switch button status
      */
-    enum ShutdownSignal_e
+    enum PowerSwitchStatus_e
     {
-        SHUTDOWN_FALSE = 0,  //!< Shutdown signal is not set
-        SHUTDOWN_TRUE        //!< Shutdown signal is set
+        POWERSWITCH_PRESSED = 0,  //!< The power switch button is pressed
+        POWERSWITCH_UNPRESSED     //!< The power switch button is not pressed
     };
 
     /**
@@ -102,7 +102,7 @@ private:
     IDigitalIO& digitalIO;
 
     void setPowerSignal(PowerState_e state);
-    ShutdownSignal_e getShutdownSignal();
+    PowerSwitchStatus_e getShutdownSignal();
 
 };
 

--- a/src/controlblock/app/PowerSwitch.h
+++ b/src/controlblock/app/PowerSwitch.h
@@ -58,13 +58,23 @@ public:
         POWERSWITCH_ENABLED       //!< Power switch is enabled
     };
 
+    /***
+     * Indicates what type of power switch that is used
+     */
+    enum PowerSwitchType_e
+    {
+        SWITCHTYPE_MOMENTARY = 0, //!< Power switch is a momentary switch
+        SWITCHTYPE_LATCHING       //!< Power switch is a latching switch
+    };
+
     /**
      * Constructor
      * @param digitalInReference - Reference with IDigitalIn interface
      * @param digitalOutReference - Reference with IDigitalOut interface
      * @param powerSwitchEnabledValue - Power switch function is enabled or not
+     * @param powerSwitchTypeValue - Type of power switch used
      */
-    explicit PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e powerSwitchEnabledValue);
+    explicit PowerSwitch(IDigitalIO& digitalIOReference, PowerSwitchEnabled_e powerSwitchEnabledValue, PowerSwitchType_e powerSwitchTypeValue);
 
     /**
      * Destructor
@@ -87,6 +97,7 @@ public:
 
 private:
     PowerSwitchEnabled_e powerSwitchEnabled;
+    PowerSwitchType_e powerSwitchType;
     bool isShutdownInitiatedValue;
     IDigitalIO& digitalIO;
 

--- a/src/controlblock/config/ControlBlockConfiguration.cpp
+++ b/src/controlblock/config/ControlBlockConfiguration.cpp
@@ -64,12 +64,12 @@ void ControlBlockConfiguration::loadConfiguration()
                 (uint8_t) (root["controlblocks"][0]["address"]["SJ2"].asInt() << 2
                          | root["controlblocks"][0]["address"]["SJ1"].asInt() << 1),
                 root["controlblocks"][0]["gamepadtype"].asString(), root["controlblocks"][0]["powerswitchOn"].asBool(),
-                root["controlblocks"][0]["onlyOneGamepad"].asBool());
+                root["controlblocks"][0]["momentarySwitch"].asBool(), root["controlblocks"][0]["onlyOneGamepad"].asBool());
         singleConfiguration[1] = new SingleConfiguration(root["controlblocks"][1]["enabled"].asBool(),
                 (uint8_t) (root["controlblocks"][1]["address"]["SJ2"].asInt() << 2
                          | root["controlblocks"][1]["address"]["SJ1"].asInt() << 1),
                 root["controlblocks"][1]["gamepadtype"].asString(), root["controlblocks"][1]["powerswitchOn"].asBool(),
-                root["controlblocks"][1]["onlyOneGamepad"].asBool());
+                root["controlblocks"][1]["momentarySwitch"].asBool(), root["controlblocks"][1]["onlyOneGamepad"].asBool());
     }
     catch (int errno) {
         std::cout << "Error while initializing ControlBlockConfiguration instance. Error number: " << errno

--- a/src/controlblock/config/SingleConfiguration.cpp
+++ b/src/controlblock/config/SingleConfiguration.cpp
@@ -24,10 +24,11 @@
 #include "SingleConfiguration.h"
 
 SingleConfiguration::SingleConfiguration(bool enabled, uint8_t address, std::string pType, bool pwrSwitch,
-        bool oneGp) :
+        bool momentSwitch, bool oneGp) :
                 isEnabledValue(enabled),
                 deviceAddress(address),
                 isPowerSwitchEnabledValue(pwrSwitch),
+                isPowerSwitchMomentaryValue(momentSwitch),
                 isOnlyOneGamepadEnabledValue(oneGp)
 {
     if (pType.compare("arcade") == 0)
@@ -78,6 +79,11 @@ InputDevice::GamepadType_e SingleConfiguration::getGamepadType()
 bool SingleConfiguration::isPowerSwitchEnabled()
 {
     return isPowerSwitchEnabledValue;
+}
+
+bool SingleConfiguration::isPowerSwitchMomentary()
+{
+    return isPowerSwitchMomentaryValue;
 }
 
 bool SingleConfiguration::isOnlyOneGamepadEnabled()

--- a/src/controlblock/config/SingleConfiguration.h
+++ b/src/controlblock/config/SingleConfiguration.h
@@ -38,9 +38,10 @@ public:
      * @param address - The hardware address
      * @param type - The type of the gamepad
      * @param pwrSwitch - Whether the power switch functionality is enabled (=true) or not (=false)
+     * @param momentSwitch - Whether the power switch is momentary (=true) or latching (=false)
      * @param oneGp - Whether one (=true) or two (=false) gamepads should be registered
      */
-    SingleConfiguration(bool enabled, uint8_t address, std::string type, bool pwrSwitch, bool oneGp);
+    SingleConfiguration(bool enabled, uint8_t address, std::string type, bool pwrSwitch, bool momentSwitch, bool oneGp);
 
     /**
      * Destructor
@@ -76,6 +77,14 @@ public:
     virtual bool isPowerSwitchEnabled();
 
     /**
+     * Returns whether the power switch is momentary or not
+     * @return
+     *  - true, if the power switch is momentary,
+     *  - false, if the power switch is latching.
+     */
+    virtual bool isPowerSwitchMomentary();
+
+    /**
      * Returns whether only one gamepad should be enabled or not
      * @return
      *  - true, if only one gamepad should be enabled,
@@ -88,6 +97,7 @@ private:
     uint8_t deviceAddress;
     InputDevice::GamepadType_e padType;
     bool isPowerSwitchEnabledValue;
+    bool isPowerSwitchMomentaryValue;
     bool isOnlyOneGamepadEnabledValue;
 };
 

--- a/supplementary/controlblockconfig.cfg
+++ b/supplementary/controlblockconfig.cfg
@@ -8,7 +8,8 @@
 			},
 			"gamepadtype" : "arcade",  // Sets the gamepad type. Options: "arcade", "mame", "snes", "none"
 			"onlyOneGamepad" : false,  // If true, registers only one gamepad instead of two
-			"powerswitchOn" : true     // Enables (=true) the power switch functionality. Options: true, false
+			"powerswitchOn" : true,     // Enables (=true) the power switch functionality. Options: true, false
+			"momentarySwitch" : false   // Set to true if the power switch is a momentary switch, false if the switch is latching. Options: true, false
 		},
 		{
 			"enabled" : false,          // Enables (=true) or disables (=false) the second ControlBlock 

--- a/test/controlblock/app/PowerSwitchTest.cpp
+++ b/test/controlblock/app/PowerSwitchTest.cpp
@@ -37,7 +37,7 @@ TEST(PowerSwitchTest, Constructor)
     EXPECT_CALL(doMock, configureDevice(IDigitalOut::DO_DEVICE_POWERSWITCH));
     EXPECT_CALL(doMock, setLevel(IDigitalOut::DO_CHANNEL_TOPOWERSWITCH, IDigitalOut::DO_LEVEL_HIGH, IDigitalOut::BOARD_0));
     EXPECT_CALL(diMock, configureDevice(IDigitalIn::DI_DEVICE_POWERSWITCH));
-    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::SHUTDOWN_ACTIVATED);
+    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::POWERSWITCH_ENABLED, PowerSwitch::SWITCHTYPE_LATCHING);
     EXPECT_FALSE(powerSwitch.isShutdownInitiated());
 }
 
@@ -45,17 +45,17 @@ TEST(PowerSwitchTest, updateWithNoShutdownActivated_ExpectNoShutdown)
 {
     NiceMock<DigitalOutMock> doMock;
     NiceMock<DigitalInMock> diMock;
-    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::SHUTDOWN_DEACTIVATED);
+    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::POWERSWITCH_DISABLED, PowerSwitch::SWITCHTYPE_LATCHING);
 
     powerSwitch.update();
     EXPECT_FALSE(powerSwitch.isShutdownInitiated());
 }
 
-TEST(PowerSwitchTest, updateAndExpectShutdown)
+TEST(PowerSwitchTest, updateAndExpectShutdownLatching)
 {
     NiceMock<DigitalOutMock> doMock;
     NiceMock<DigitalInMock> diMock;
-    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::SHUTDOWN_ACTIVATED);
+    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::POWERSWITCH_ENALBED, PowerSwitch::SWITCHTYPE_LATCHING);
 
     EXPECT_CALL(diMock, getLevel(IDigitalIn::DI_CHANNEL_FROMPOWERSWITCH, IDigitalIn::BOARD_0)).WillOnce(Return(IDigitalIn::DI_LEVEL_HIGH));
 
@@ -63,13 +63,37 @@ TEST(PowerSwitchTest, updateAndExpectShutdown)
     EXPECT_TRUE(powerSwitch.isShutdownInitiated());
 }
 
-TEST(PowerSwitchTest, updateAndExpectNoShutdown)
+TEST(PowerSwitchTest, updateAndExpectNoShutdownLatching)
 {
     NiceMock<DigitalOutMock> doMock;
     NiceMock<DigitalInMock> diMock;
-    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::SHUTDOWN_ACTIVATED);
+    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::POWERSWITCH_ENABLED, PowerSwitch::SWITCHTYPE_LATCHING);
 
     EXPECT_CALL(diMock, getLevel(IDigitalIn::DI_CHANNEL_FROMPOWERSWITCH, IDigitalIn::BOARD_0)).WillOnce(Return(IDigitalIn::DI_LEVEL_LOW));
+
+    powerSwitch.update();
+    EXPECT_FALSE(powerSwitch.isShutdownInitiated());
+}
+
+TEST(PowerSwitchTest, updateAndExpectShutdownMomentary)
+{
+    NiceMock<DigitalOutMock> doMock;
+    NiceMock<DigitalInMock> diMock;
+    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::POWERSWITCH_ENALBED, PowerSwitch::SWITCHTYPE_MOMENTARY);
+
+    EXPECT_CALL(diMock, getLevel(IDigitalIn::DI_CHANNEL_FROMPOWERSWITCH, IDigitalIn::BOARD_0)).WillOnce(Return(IDigitalIn::DI_LEVEL_LOW));
+
+    powerSwitch.update();
+    EXPECT_TRUE(powerSwitch.isShutdownInitiated());
+}
+
+TEST(PowerSwitchTest, updateAndExpectNoShutdownMomentary)
+{
+    NiceMock<DigitalOutMock> doMock;
+    NiceMock<DigitalInMock> diMock;
+    PowerSwitch powerSwitch(diMock, doMock, PowerSwitch::POWERSWITCH_ENABLED, PowerSwitch::SWITCHTYPE_MOMENTARY);
+
+    EXPECT_CALL(diMock, getLevel(IDigitalIn::DI_CHANNEL_FROMPOWERSWITCH, IDigitalIn::BOARD_0)).WillOnce(Return(IDigitalIn::DI_LEVEL_HIGH));
 
     powerSwitch.update();
     EXPECT_FALSE(powerSwitch.isShutdownInitiated());

--- a/test/controlblock/config/SingleConfigurationMock.h
+++ b/test/controlblock/config/SingleConfigurationMock.h
@@ -33,6 +33,7 @@ public:
     MOCK_METHOD0(getDeviceAddress, uint8_t());
     MOCK_METHOD0(getGamepadType, GamepadType_e());
     MOCK_METHOD0(isPowerSwitchEnabled, bool());
+    MOCK_METHOD0(isPowerSwitchMomentary, bool());
     MOCK_METHOD0(isOnlyOneGamepadEnabled, bool());
 };
 


### PR DESCRIPTION
This pull request implements support for both momentary and latching power switches.

It works by adding a setting to the configuration file, allowing the user to select what type of button is used.
If the setting is missing or set to false, it works as a latching button (to ensure people upgrading won't notice any changes) - if it is set to true, it will work as a momentary button.

I have renamed a few of the enum's, to improve readability, and to have it make more sense with both latching and momentary buttons (since having the two pins shorted on the PCB has opposite meanings, depending on the type of switch).

I'm still waiting for my ControlBlock to arrive in the mail, so I haven't tested this yet, except for the unit tests.

If you have any feedback, don't hold back.
I'll update the pull requests as soon as I have had a chance to test it.